### PR TITLE
#159965492 Add pagination for articles

### DIFF
--- a/authors/apps/articles/renderers.py
+++ b/authors/apps/articles/renderers.py
@@ -2,39 +2,24 @@ from rest_framework.renderers import JSONRenderer
 import json
 
 
-class AuthorsJSONRenderer(JSONRenderer):
+class ArticleJSONRenderer(JSONRenderer):
+    object_label = 'article'
     charset = 'utf-8'
-    object_label = 'object'
-    pagination_object_label = 'objects'
-    pagination_object_count = 'count'
+    # pagination_object_label = 'articles'
+    # pagination_count_label = 'articlesCount'
 
     def render(self, data, media_type=None, renderer_context=None):
-        if data.get('results', None) is not None:
+        """
+        Render the articles in a structured manner for the end user.
+        """
+        if data is not None:
+            if len(data) <= 1:
+                return json.dumps({
+                    'article': data
+                })
             return json.dumps({
-                self.pagination_count_label: data['count'],
-                self.pagination_object_label: data['results'],
+                'articles': data
             })
-
-        # If the view throws an error (such as the user can't be authenticated
-        # default json handler should handle
-
-        elif data.get('errors', None) is not None:
-            return super(AuthorsJSONRenderer, self).render(data)
-
-        else:
-            return json.dumps({
-                self.object_label: data
-            })
-
-
-class ArticleJSONRenderer(AuthorsJSONRenderer):
-    object_label = 'article'
-    pagination_object_label = 'articles'
-    pagination_count_label = 'articlesCount'
-
-
-
-
-
-
-
+        return json.dumps({
+            'article': 'No article found.'
+        })

--- a/authors/apps/articles/test_articles.py
+++ b/authors/apps/articles/test_articles.py
@@ -169,13 +169,13 @@ class ArticleTestCase(BaseTest):
                format='json')
         token = response.data['token']
         article= self.testArticle
+        # runs create article 21 times so as to create multiple articles
         for i in range(0, 21):
             response = self.create_article(token, article)
         else:
             pass
 
         response = self.client.get('/api/articles')
-        print(response.data)
         self.assertEquals(response.data['count'], 21)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/authors/apps/articles/test_articles.py
+++ b/authors/apps/articles/test_articles.py
@@ -153,6 +153,32 @@ class ArticleTestCase(BaseTest):
         response = self.client.get('/api/articles')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_any_user_can_get_paginated_articles(self):
+        """
+        Test user can view paginated data
+        """
+        # Signs up User
+        response = self.client.post(
+               self.SIGN_UP_URL,
+               self.user_cred,
+               format='json')
+        # Signs in User
+        response = self.client.post(
+               reverse('authentication:user_login'),
+               self.user_cred,
+               format='json')
+        token = response.data['token']
+        article= self.testArticle
+        for i in range(0, 21):
+            response = self.create_article(token, article)
+        else:
+            pass
+
+        response = self.client.get('/api/articles')
+        print(response.data)
+        self.assertEquals(response.data['count'], 21)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
 
     def test_unverified_user_cannot_create_article(self):
         """

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -9,6 +9,7 @@ from rest_framework.views import APIView
 from .models import Article
 from .renderers import ArticleJSONRenderer
 from .serializers import ArticleSerializer
+from rest_framework.pagination import LimitOffsetPagination
 
 
 class ArticleViewSet(mixins.CreateModelMixin, 
@@ -25,6 +26,7 @@ class ArticleViewSet(mixins.CreateModelMixin,
     permission_classes = (IsAuthenticatedOrReadOnly,)
     renderer_classes = (ArticleJSONRenderer,)
     serializer_class = ArticleSerializer
+    pagination_class = LimitOffsetPagination
 
     def get_queryset(self):
         queryset = self.queryset
@@ -61,7 +63,7 @@ class ArticleViewSet(mixins.CreateModelMixin,
         '''
 
         serializer_context = {'request': request}
-        page = self.paginate_queryset(self.get_queryset())
+        page = self.paginate_queryset(self.queryset)
 
         serializer = self.serializer_class(
             page,

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -153,7 +153,7 @@ REST_FRAMEWORK = {
         'authors.apps.authentication.backends.JWTAuthentication',
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
-    'PAGE_SIZE': 2,
+    'PAGE_SIZE': 5,
 }
 
 EMAIL_USE_TLS = True

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -153,7 +153,7 @@ REST_FRAMEWORK = {
         'authors.apps.authentication.backends.JWTAuthentication',
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
-    'PAGE_SIZE': 10,
+    'PAGE_SIZE': 2,
 }
 
 EMAIL_USE_TLS = True


### PR DESCRIPTION
## What does this PR do?
```
- Adds Pagination support for articles.
```

## Description of Task to be completed?
```
Pagination support is lacking for our articles. Reading can be a nightmare when we have so many articles. 

```

## How should this be manually tested?

```
- Clone this repo and pip install requirements.txt
- Sign up and Sign in 
- Navigate to this endpoint http://127.0.0.1:8000/api/articles
- Post more the five articles and run get
- You will notice that only five articles are returned with next and previous 
   endpoints automatically generated

```

## What are the relevant pivotal tracker stories?

[#159965492](https://www.pivotaltracker.com/story/show/159965492)


## Screenshots if available to support PR.

<img width="1121" alt="screen shot 2018-09-11 at 16 03 11" src="https://user-images.githubusercontent.com/39088834/45363064-294c4980-b5df-11e8-8d24-8789ecd9d6fc.png">



## Questions:

```
Was this PR helpful?

```