### PR TITLE
Ft implement search custom filter 159965493

### DIFF
--- a/authors/apps/articles/test_search_filter_articles.py
+++ b/authors/apps/articles/test_search_filter_articles.py
@@ -1,0 +1,226 @@
+from ..base_test import BaseTest
+from django.urls import reverse
+from rest_framework.views import status
+import json
+
+class ArticleTestCase(BaseTest):
+    """ 
+    Class implements tests for artcles
+    """
+    
+    def create_article(self, token, article):
+        """
+        Helper method to creates an article
+        """
+        return self.client.post(
+            '/api/articles',
+            article,
+            HTTP_AUTHORIZATION='Bearer ' + token,
+
+            format='json'
+        )
+
+
+    def test_search_article_by_title_successfully(self):
+        """ 
+        Test an article can be searched by title
+        and returned successfully
+
+        """
+
+        response = self.client.post(
+               self.SIGN_UP_URL,
+               self.user_cred,
+               format='json')
+        response = self.client.post(
+               reverse('authentication:user_login'),
+               self.user_cred,
+               format='json')
+        token = response.data['token']
+
+        article= {
+                    "article": 
+                      {
+                      "title": "How to feed your dragon",
+                      "description": "Wanna know how?",
+                      "body": "You don't believe?",
+                        }
+                  }
+        
+        response = self.create_article(token, article)
+        response = self.client.get('/api/search/articles?title=dragon')
+
+
+        self.assertEquals(status.HTTP_200_OK, response.status_code)
+
+    def test_search_article_by_tag_successfully(self):
+        """ 
+        Test an article can be searched by title and returned 
+        successfully
+
+        """
+
+        response = self.client.post(
+               self.SIGN_UP_URL,
+               self.user_cred,
+               format='json')
+        response = self.client.post(
+               reverse('authentication:user_login'),
+               self.user_cred,
+               format='json')
+        token = response.data['token']
+
+        article= {
+                    "article": 
+                        {
+                            "title": "How to train your dragon",
+                            "description": "Ever wonder how?",
+                            "body": "You have to believe",
+                            "tagList": ["reactjs", "angularjs", "dragons"]
+                        }
+                }
+
+        
+        response = self.create_article(token, article)
+        response = self.client.get('/api/search/articles?tagList=reactjs')
+
+
+        self.assertEquals(status.HTTP_200_OK, response.status_code)
+
+    def test_search_article_by_author_successfully(self):
+        """ 
+        Test an article can be searched by author
+        and returned successfully
+
+        """
+
+        response = self.client.post(
+               self.SIGN_UP_URL,
+               self.user_cred,
+               format='json')
+        response = self.client.post(
+               reverse('authentication:user_login'),
+               self.user_cred,
+               format='json')
+        token = response.data['token']
+
+        article= {
+                    "article": 
+                        {
+                            "title": "How to train your dragon",
+                            "description": "Ever wonder how?",
+                            "body": "You have to believe",
+                            "tagList": ["reactjs", "angularjs", "dragons"]
+                        }
+                }
+
+        
+        response = self.create_article(token, article)
+        response = self.client.get('/api/search/articles?search=jake')
+
+
+        self.assertEquals(status.HTTP_200_OK, response.status_code)
+
+
+    def test_search_article_by_author_not_found(self):
+        """ 
+        Test an article can be searched by title not found
+        Count and results should be zero and empty respectively
+
+        """
+
+        response = self.client.post(
+               self.SIGN_UP_URL,
+               self.user_cred,
+               format='json')
+        response = self.client.post(
+               reverse('authentication:user_login'),
+               self.user_cred,
+               format='json')
+        token = response.data['token']
+
+        article= {
+                    "article": 
+                        {
+                            "title": "How to train your dragon",
+                            "description": "Ever wonder how?",
+                            "body": "You have to believe",
+                            "tagList": ["reactjs", "angularjs", "dragons"]
+                        }
+                }
+
+        
+        response = self.create_article(token, article)
+        response = self.client.get('/api/search/articles?search=jakeee')
+        self.assertEqual(response.data['count'], 0)
+        self.assertEqual(response.data['results'], [])
+        self.assertEquals(status.HTTP_200_OK, response.status_code)
+
+
+    def test_search_article_by_title_not_found(self):
+        """ 
+        Test an article can be searched by title not found
+        Count and results should be zero and empty respectively
+
+        """
+
+        response = self.client.post(
+               self.SIGN_UP_URL,
+               self.user_cred,
+               format='json')
+        response = self.client.post(
+               reverse('authentication:user_login'),
+               self.user_cred,
+               format='json')
+        token = response.data['token']
+
+        article= {
+                    "article": 
+                        {
+                            "title": "How to train your dragon",
+                            "description": "Ever wonder how?",
+                            "body": "You have to believe",
+                            "tagList": ["reactjs", "angularjs", "dragons"]
+                        }
+                }
+
+        
+        response = self.create_article(token, article)
+        response = self.client.get('/api/search/articles?title=dragonnn')
+        self.assertEqual(response.data['count'], 0)
+        self.assertEqual(response.data['results'], [])
+        self.assertEquals(status.HTTP_200_OK, response.status_code)
+
+    def test_search_article_by_tag_not_found(self):
+        """ 
+        Test an article can be searched by title not found
+        Count and results should be zero and empty respectively
+
+        """
+
+        response = self.client.post(
+               self.SIGN_UP_URL,
+               self.user_cred,
+               format='json')
+        response = self.client.post(
+               reverse('authentication:user_login'),
+               self.user_cred,
+               format='json')
+        token = response.data['token']
+
+        article= {
+                    "article": 
+                        {
+                            "title": "How to train your dragon",
+                            "description": "Ever wonder how?",
+                            "body": "You have to believe",
+                            "tagList": ["reactjs", "angularjs", "dragons"]
+                        }
+                }
+
+        
+        response = self.create_article(token, article)
+        response = self.client.get('/api/search/articles?tagList=dragonnn')
+        self.assertEqual(response.data['count'], 0)
+        self.assertEqual(response.data['results'], [])
+        self.assertEquals(status.HTTP_200_OK, response.status_code)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import include, url
 
 from rest_framework.routers import DefaultRouter
 
-from .views import ArticleViewSet
+from .views import ArticleViewSet, ArticleSearchList
 
 router = DefaultRouter(trailing_slash=False)
 router.register(r'articles', ArticleViewSet,
@@ -11,6 +11,7 @@ router.register(r'articles', ArticleViewSet,
 app_name = 'articles'
 urlpatterns = [
     url(r'^', include(router.urls)),
+    url(r'^search/articles$', ArticleSearchList.as_view(), name="search"),
 
 
 ]

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -46,6 +46,8 @@ INSTALLED_APPS = [
     'authors.apps.core',
     'authors.apps.profiles',
     'authors.apps.articles',
+    'django_filters',
+    'django.contrib.postgres'
 ]
 
 MIDDLEWARE = [
@@ -153,7 +155,11 @@ REST_FRAMEWORK = {
         'authors.apps.authentication.backends.JWTAuthentication',
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
-    'PAGE_SIZE': 5,
+    'PAGE_SIZE': 10,
+    'DEFAULT_FILTER_BACKENDS': (
+        'django_filters.rest_framework.DjangoFilterBackend',
+        
+        ),
 }
 
 EMAIL_USE_TLS = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,11 @@ celery==4.2.1
 dj-database-url==0.5.0
 Django==2.1
 django-cors-middleware==1.3.1
-django-extensions==2.1.1
+django-extensions==2.1.2
+django-filter==2.0.0
+django-filters==0.2.1
 djangorestframework==3.8.2
+djangorestframework-filters==0.10.2
 docopt==0.6.2
 flake8==3.5.0
 gunicorn==19.9.0
@@ -28,6 +31,7 @@ mccabe==0.6.1
 psycopg2==2.7.5
 more-itertools==4.3.0
 pluggy==0.7.1
+Pillow==2.2.1
 psycopg2-binary==2.7.5
 py==1.6.0
 pycodestyle==2.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,6 @@ mccabe==0.6.1
 psycopg2==2.7.5
 more-itertools==4.3.0
 pluggy==0.7.1
-Pillow==2.2.1
 psycopg2-binary==2.7.5
 py==1.6.0
 pycodestyle==2.3.1


### PR DESCRIPTION
## What does this PR do?
```
Implements search and filtering functionality for articles.
```

## Description of Task to be completed?
```
This PR adds a search and filtering function to AuthorsHaven. Users should be able to filter and search by either title, tag, author.

```

## How should this be manually tested?

```
Clone the repo to the desktop. CD into ah-leagueOfLegends. pip install -r requirements.txt and run the server using: python manage.py runserver.
Create articles using HTTP POST on: http://127.0.0.1:8000/api/articles.
To get an article using slag:
Create an HTTP GET on:
http://127.0.0.1:8000/api/search/articles?tagList=reactjs
To get an article using title:
Create an HTTP GET on:
http://127.0.0.1:8000/api/search/articles?title=dragon


```
## Any background context you want to provide?

```
Users could not search or filter articles.

```

## What are the relevant pivotal tracker stories?

[#159965493](link)


## Screenshots if available to support PR.

<img width="1440" alt="screen shot 2018-09-12 at 12 22 37" src="https://user-images.githubusercontent.com/39365725/45415579-a41c6f80-b686-11e8-9f9a-29dbaca17423.png">
<img width="1440" alt="screen shot 2018-09-12 at 12 23 47" src="https://user-images.githubusercontent.com/39365725/45415627-b8f90300-b686-11e8-9ba8-6f38be8468b0.png">


