### PR TITLE
#159965490 List Users functionality

### DIFF
--- a/authors/apps/profiles/test/test_profiles.py
+++ b/authors/apps/profiles/test/test_profiles.py
@@ -13,7 +13,7 @@ class ProfileTestCase(BaseTest):
                 "bio":"Through the lense",
             }
             }
-        
+    # helper methods  
     def update_user_bio(self, token,bio):
         """Helper method to update an user bio"""
         return self.client.put(
@@ -30,6 +30,14 @@ class ProfileTestCase(BaseTest):
             HTTP_AUTHORIZATION='Bearer ' + token,
             format='json'
         )
+    def retrieve_profiles(self, token):
+        """Helper method to update an user bio"""
+        return self.client.get(
+            '/api/profiles',
+            HTTP_AUTHORIZATION='Bearer ' + token,
+        )
+
+    # unit tests
 
     def test_user_can_create_profile(self):
         """ Test if user profile is created """ 
@@ -48,22 +56,51 @@ class ProfileTestCase(BaseTest):
 
     
     def test_update_bio(self):
-            """ 
-            Tests whether a user can update his/her profile bio
-            """
-            self.register_user()
-            response = self.login_user()
-            token = response.data['token']
-            response = self.update_user_bio(token,self.bio)
-            self.assertEquals(status.HTTP_200_OK, response.status_code)
+        """ 
+        Tests whether a user can update his/her profile bio
+        """
+        self.register_user()
+        response = self.login_user()
+        token = response.data['token']
+        response = self.update_user_bio(token,self.bio)
+        self.assertEquals(status.HTTP_200_OK, response.status_code)
 
     def test_update_image(self):
-            """ 
-            Tests whether a user can update his/her profile bio
-            """
-            self.register_user()
-            response = self.login_user()
-            token = response.data['token']
-            response = self.update_user_image(token,self.image)
-            self.assertEquals(status.HTTP_200_OK, response.status_code)
+        """ 
+        Tests whether a user can update his/her profile bio
+        """
+        self.register_user()
+        response = self.login_user()
+        token = response.data['token']
+        response = self.update_user_image(token,self.image)
+        self.assertEquals(status.HTTP_200_OK, response.status_code)
+    
+    def test_list_profiles(self):
+        """ 
+        Tests whether a user profile can be listed after authentication.
+        """
+        self.register_user()
+        response = self.login_user()
+        token = response.data['token']
+        response = self.retrieve_profiles(token)
+        self.assertEquals(status.HTTP_200_OK, response.status_code)
+
+    def test_list_profiles_without_authentication(self):
+        """ 
+        Tests whether a user profile can be listed without authentication.
+        """
+        self.register_user()
+        token = ''
+        response = self.retrieve_profiles(token)
+        self.assertEquals(status.HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_paginated_profile_list(self):
+        """
+        Test user can view paginated data
+        """
+        self.register_user()
+        response = self.login_user()
+        token = response.data['token']
+        response = self.retrieve_profiles(token)
+        self.assertEquals(response.data['count'], 1)
     

--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -1,8 +1,9 @@
-from django.urls import include, re_path
+from django.urls import include, re_path,path
 
-from .views import ProfileRetrieveAPIView
+from .views import ProfileRetrieveAPIView, ProfileList
 
 app_name = 'profiles'
 urlpatterns = [
+  path('', ProfileList.as_view()),
   re_path(r'(?P<username>\w+)?$', ProfileRetrieveAPIView.as_view()),
 ] 

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -1,7 +1,8 @@
 from rest_framework import status
-from rest_framework.generics import RetrieveAPIView
-from rest_framework.permissions import AllowAny
+from rest_framework.generics import RetrieveAPIView, ListAPIView
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.pagination import LimitOffsetPagination
 
 from .models import Profile
 from .exceptions import ProfileDoesNotExist
@@ -26,3 +27,20 @@ class ProfileRetrieveAPIView(RetrieveAPIView):
         serializer = self.serializer_class(profile)
 
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+class ProfileList(ListAPIView):
+    '''Retrives all profiles from the database'''
+    permission_classes = (IsAuthenticated,)
+    queryset = Profile.objects.all()
+    serializer_class = ProfileSerializer
+    pagination_class = LimitOffsetPagination
+
+    def list(self, request):
+        serializer_context = {'request': request}
+        page = self.paginate_queryset(self.queryset)
+        serializer = self.serializer_class(
+           page,
+           context=serializer_context,
+           many=True
+        )
+        return self.get_paginated_response(serializer.data)


### PR DESCRIPTION
## What does this PR do?
```
This PR enables authenticated users to see the list and profiles of existing authors
```
## Description of Task to be completed?

- Create unit tests for listing profiles.
- Create A profile list view.
- Add pagination

## How should this be manually tested?

- Checkout ```ft-list-users-159965490``` branch
- Run the server ```$python manage.py runserver```
- Fire up postman and send a POST request to ```http://127.0.0.1:8000/api/users/``` for signing up 
```{
 {
  "user":{
    "username": "dvlpr",
    "email": "dvlpr@gmail.com",
    "password": "!developR2"
  }
}
}
```
- Then send a GET request to ```http://127.0.0.1:8000/api/profiles```
-A paginated list of created profiles will be displayed, including the count.

## What are the relevant pivotal tracker stories?
[#2192365](https://www.pivotaltracker.com/n/projects/2192365)

## Screenshots if available to support PR.

<img width="1125" alt="screen shot 2018-09-18 at 12 01 26" src="https://user-images.githubusercontent.com/28872296/45676540-a5dcac00-bb3a-11e8-9d5f-58bfd40e0f83.png">

