### PR TITLE
#159965482 Implements a get endpoint to return currently logged in initial rating if it exists.

### DIFF
--- a/authors/apps/authentication/test/test_social_login.py
+++ b/authors/apps/authentication/test/test_social_login.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from django.urls import reverse
 from rest_framework.test import APITestCase, APIClient
-
+import os
 
 
 class SocialAuthenticationTests(APITestCase):
@@ -17,9 +17,10 @@ class SocialAuthenticationTests(APITestCase):
         """
         Test signing up of new user
         """
-        access_token = "1039235309043675137-l3x3MgsuqaePx9qBikXPMKVr13lMgj"
-        access_token_secret = "UFlDOMdDhUnzNXkQW4NArKzvdJPmxPrDSyXJiQwoipZCl"
-        data = {"provider": "twitter", "access_token": access_token, "access_token_secret": access_token_secret}
+        access_token = os.getenv("test_twitter_access_token")
+        access_token_secret = os.getenv("test_twitter_access_token_secret")
+        data = {"provider": "twitter", "access_token": access_token,
+                "access_token_secret": access_token_secret}
         response = self.client.post(self.auth_url, data=data)
         self.assertEqual(response.status_code, 200)
 
@@ -31,7 +32,6 @@ class SocialAuthenticationTests(APITestCase):
         response = self.client.post(self.auth_url, data=data)
         self.assertEqual(response.status_code, 400)
 
-
     def test_missing_provider(self):
         """
         Test request without passing the provider
@@ -41,7 +41,6 @@ class SocialAuthenticationTests(APITestCase):
         response = self.client.post(self.auth_url, data=data)
         self.assertEqual(response.status_code, 400)
 
-
     def test_invalid_provider(self):
         """
         Test giving a non-existent provider
@@ -50,7 +49,6 @@ class SocialAuthenticationTests(APITestCase):
         data = {"access_token": access_token, "provider": "facebook-oauth23"}
         response = self.client.post(self.auth_url, data=data)
         self.assertEqual(response.status_code, 400)
-
 
     def test_invalid_token(self):
         """


### PR DESCRIPTION


## What does this PR do?
```
Implements an endpoint to return a user's initial rating of an article if it exists.
```

## Description of Task to be completed?
```
Authors Haven backend requires an endpoint to get a user's initial rating if available in the database.
This feature is helpful to serve front-end implementation of article rating function.
A user should be able to see the initial rating and be able to update such rating if he/she feels necessary

```

## How should this be manually tested?

```
Clone the repo ah-leagueOfLegends. cd into ah-leagueOfLegends. pip install -r requirements.txt. 
Rate an article on the following endpoint with POST:http://127.0.0.1:8000/api/articles/how-to-train-your-dragon-4/rate/. 
GET  initial rating using GET request: http://127.0.0.1:8000/api/articles/how-to-train-your-dragon-4/rate/.


```
## Any background context you want to provide?

```
Authors Haven did not have an endpoint to return a user's initial rating.

```

## What are the relevant pivotal tracker stories?

[#159965482](https://www.pivotaltracker.com/story/show/159965482


## Screenshots if available to support PR.

<img width="945" alt="screen shot 2018-10-16 at 08 24 36" src="https://user-images.githubusercontent.com/39365725/46994170-f3d5d700-d11b-11e8-9ba2-37a7df2692eb.png">



