### PR TITLE
#161479706 return user notification subscription status

### DIFF
--- a/authors/apps/profiles/serializers.py
+++ b/authors/apps/profiles/serializers.py
@@ -8,6 +8,7 @@ class ProfileSerializer(serializers.ModelSerializer):
     date_joined = serializers.CharField(source='user.created_at')
     bio = serializers.CharField(allow_blank=True, required=False)
     image = serializers.URLField()
+    get_notifications = serializers.BooleanField()
     bookmarks = serializers.SlugRelatedField(
         many=True,
         read_only=True,
@@ -18,7 +19,7 @@ class ProfileSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Profile
-        fields = ('username', 'bio', 'image','date_joined','following','bookmarks',)
+        fields = ('username', 'bio', 'image','date_joined','following','bookmarks', 'get_notifications')
         read_only_fields = ('username',)
         
     def get_following(self, instance):


### PR DESCRIPTION
## What does this PR do?
```
Add notification subscription status to retrieved profiles
```

## Description of Task to be completed?
```
Adds get_notification field to the profile serializer

```

## How should this be manually tested?

```
Check out bg-add-subscription-status-161479706
Fetch profiles 'api/profiles'

```
## Any background context you want to provide?

```
There has to be a way to tell whether a user is subscribed to notifications or not in the frontend. By returning the get_notifications field, it will facilitate a state check in the frontend which will determine the initial position of the toggle switch

```

## What are the relevant pivotal tracker stories?

[#161479706](https://www.pivotaltracker.com/story/show/161479706)

