### PR TITLE
#161502366 Fix the like, dislike of comments feature

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -142,6 +142,9 @@ class CommentSerializer(serializers.ModelSerializer):
     mediate between comment model and python primitives
     '''
     author = UserSerializer(read_only=True)
+    likes = serializers.SerializerMethodField(method_name='likes_count')
+    dislikes = serializers.SerializerMethodField(method_name='dislikes_count')
+
 
     class Meta:
         model = Comment
@@ -151,6 +154,8 @@ class CommentSerializer(serializers.ModelSerializer):
             'updated_at',
             'body',
             'author',
+            'likes',
+            'dislikes',
         )
 
     def create(self, validated_data):
@@ -169,6 +174,18 @@ class CommentSerializer(serializers.ModelSerializer):
         notify.send(author, recipient=recipients, 
                     verb="commented on", action_object=article)
         return comment
+
+    def likes_count(self, instance):
+       """
+       Gets the total number of likes for a particular comment
+       """
+       return instance.likes.count()
+
+    def dislikes_count(self, instance):
+       """
+       Gets the total number of dislikes for a particular comment
+       """
+       return instance.dislikes.count()    
 
 
 class RatingSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
## What does this PR do?
```
Fixes the bug in the like, dislike comments feature.

```

## Description of Task to be completed?
```
Enable counting of both comments likes and dislikes.
Enable display of the total count of likes and dislikes to a comment.

```

## How should this be manually tested?

```
Clone the repo.
Run migrations python manage.py migrate
Run the server python manage.py runserver

```
**To create article**
First Make a post request to *127.0.0.1:8000/api/v1/articles* with the following data
```
{
  "article": {
    "title": "How to train your dragon",
    "description": "Ever wonder how?",
    "body": "You have to believe",
    "tagList": ["reactjs", "angularjs", "dragons"]
  }
}
```
**Next we add a comment**
Use the slug from the output of create article in the url of our post comment
Post a comment to *127.0.0.1:8000/api/articles/How-to-train-your-dragon/comments*
```
{
  "comment": {
    "body": "His name was my name too."
  }
}


```
**Like a comment**
**PUT** *127.0.0.1:8000/api/articles/How-to-train-your-dragon/comments/1/like*

**Dislike a comment**
**PUT** *127.0.0.1:8000/api/articles/How-to-train-your-dragon/comments/1/dislike*
## Any background context you want to provide?

```
Users should be able to comment on articles they read and other users should be able to like or dislike the comments.

```
## What are the relevant pivotal tracker stories?

[#161502366](https://www.pivotaltracker.com/n/projects/2192365)